### PR TITLE
:bug: (landingPage): FIX: 랜딩 페이지 모바일에서의 렌더링 오류

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,8 @@
 import * as S from "../src/commons/styles/home";
-import "aos/dist/aos.css";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import { deviceState, userPositionState } from "../src/commons/store";
-import Head from "next/script";
-import { useQuery } from "@apollo/client";
-import { IQuery } from "../src/commons/types/generated/types";
-import { FETCH_USER } from "../src/components/units/myPage/detail/MyPageDetail.queries";
 
 export default function Home() {
   const router = useRouter();
@@ -30,9 +25,6 @@ export default function Home() {
 
   return (
     <>
-      <Head>
-        <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-      </Head>
       <S.Wrapper>
         <S.VideoBox>
           <S.Video
@@ -43,7 +35,7 @@ export default function Home() {
             preload="auto"
             playsInline
           ></S.Video>
-          <S.MainIntro data-aos="fade-up" data-aos-duration="3000">
+          <S.MainIntro>
             공허한 길거리에
             <br />
             다채로운 컨텐츠가
@@ -53,20 +45,20 @@ export default function Home() {
         </S.VideoBox>
         <S.ContentBox>
           <S.Content>
-            <div data-aos="fade-right" data-aos-duration="1000">
+            <div>
               <S.Title>내가 좋아하는 버스커와</S.Title>
               <S.Intro>
                 내가 좋아하는 버스커와 연결고리를 만들어 보실래요?
                 <br /> 주위의 라이브 공연을 찾아 연결해보세요.
               </S.Intro>
             </div>
-            <S.ImageBoxes data-aos="fade-left" data-aos-duration="1000">
+            <S.ImageBoxes>
               <S.Image src="/landing1.jpeg" />
             </S.ImageBoxes>
           </S.Content>
           {typeof window !== "undefined" && window.outerWidth < 920 ? (
             <S.Content>
-              <div data-aos="fade-right" data-aos-duration="1000">
+              <div>
                 <S.Title
                   style={{
                     display: "block",
@@ -81,16 +73,16 @@ export default function Home() {
                   주변에 있는 버스커들의 특별한 컨텐츠를 즐겨보세요
                 </S.Intro>
               </div>
-              <S.ImageBoxes data-aos="fade-left" data-aos-duration="1000">
+              <S.ImageBoxes>
                 <S.Image src="/landing2.jpeg" />
               </S.ImageBoxes>
             </S.Content>
           ) : (
             <S.Content>
-              <S.ImageBoxes data-aos="fade-right" data-aos-duration="1000">
+              <S.ImageBoxes>
                 <S.Image src="/landing2.jpeg" />
               </S.ImageBoxes>
-              <div data-aos="fade-left" data-aos-duration="1000">
+              <div>
                 <S.Title
                   style={{
                     display: "block",


### PR DESCRIPTION
이슈
- 랜딩 페이지 모바일 화면에서 오른쪽 공백 발생. 아래로 스크롤 시, 
공백 사라졌다가 맨 처음 화면으로 스크롤 하면 다시 오른쪽 공백이 생기는 이슈.

원인
- AOS 라이브러리의 fade-left 속성을 가진 컴포넌트가 오른쪽의 공간을 차지하고 있기 때문에 공백이 생겼다가,
아래로 스크롤 시, 왼쪽으로 이동하면서 오른쪽 공백이 없어져 정상 작동하는 것처럼 보임.

해결
- AOS 라이브러리 제거 및 애니메이션 효과 삭제.

closed #1 