### PR TITLE
:zap: (list): FEATURE: 리스트 페이지 fetch API 분리

### DIFF
--- a/src/components/units/artistsignup/artistSignup.container.tsx
+++ b/src/components/units/artistsignup/artistSignup.container.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { SelectProps } from "antd";
+import { Modal, SelectProps } from "antd";
 import { useRouter } from "next/router";
 import { ChangeEvent, useEffect, useState } from "react";
 import { Address } from "react-daum-postcode";
@@ -36,7 +36,7 @@ const ArtistSignupPageWrite = ({ isEdit }: IArtistSignupPageWrite) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isTeam, setIsTeam] = useState(false);
   const [isMemberEdit, setIsMemberEdit] = useState(false);
-  const [address, setAddress] = useState("");
+  const [address] = useState("");
   const [imgUrl, setImgUrl] = useState("");
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
@@ -102,7 +102,6 @@ const ArtistSignupPageWrite = ({ isEdit }: IArtistSignupPageWrite) => {
 
   const onCompleteAddressSearch = (data: Address) => {
     setIsOpen((prev) => !prev);
-    setAddress(data.address);
     localStorage.setItem("address", JSON.stringify(data.address));
   };
 
@@ -128,26 +127,24 @@ const ArtistSignupPageWrite = ({ isEdit }: IArtistSignupPageWrite) => {
   }
 
   const handleChange = (value: string) => {
+    console.log(value);
     setValue("category", value);
   };
 
   const onClickSignup = async (data: IFormData) => {
+    console.log(data);
     try {
       const result = await createArtist({
-        variables: {
-          createArtistInput: data,
-        },
-        refetchQueries: [
-          {
-            query: FETCH_ARTIST,
-          },
-        ],
+        variables: { createArtistInput: { ...data } },
+      });
+      Modal.success({
+        content: "버스커로 등록되셨습니다. 당신의 버스킹 활동을 응원합니다.",
       });
       await router.push(
         `/artistdetail/${String(result.data?.createArtist.id)}`
       );
     } catch (error) {
-      alert(error);
+      if (error instanceof Error) Modal.error({ content: error.message });
     }
   };
 

--- a/src/components/units/artistsignup/artistSignup.types.ts
+++ b/src/components/units/artistsignup/artistSignup.types.ts
@@ -43,5 +43,5 @@ export interface IFormData {
   category: string;
   description: string;
   promotion_url: string;
-  artistImageURL: string;
+  artistImageURL?: string;
 }

--- a/src/components/units/main/list/List.container.tsx
+++ b/src/components/units/main/list/List.container.tsx
@@ -1,7 +1,7 @@
 import MainListUI from "./List.presenter";
 import { Modal, SelectProps } from "antd";
 import { useRouter } from "next/router";
-import { useQuery } from "@apollo/client";
+import { useLazyQuery, useQuery } from "@apollo/client";
 import {
   IQuery,
   IQueryFetchBoardsArgs,
@@ -24,7 +24,7 @@ const MainList = () => {
     Pick<IQuery, "fetchBoards">,
     IQueryFetchBoardsArgs
   >(FETCH_BOARDS, { variables: { page: 1 } });
-  const { data: boardsDataBySearch, refetch } = useQuery<
+  const [fetchBoardsBySearch] = useLazyQuery<
     Pick<IQuery, "fetchBoardsBySearch">,
     IQueryFetchBoardsBySearchArgs
   >(FETCH_BOARDS_BY_SEARCH);
@@ -47,12 +47,16 @@ const MainList = () => {
   const handleChangeGenre = async (value: string[]) => {
     setSelectedGenre(value);
     if (value.length) {
-      await refetch({
-        searchBoardInput: { category: value, district: selectedDistrict },
+      await fetchBoardsBySearch({
+        variables: {
+          searchBoardInput: { category: value, district: selectedDistrict },
+        },
       });
     } else {
-      await refetch({
-        searchBoardInput: { page: 1, district: selectedDistrict },
+      await fetchBoardsBySearch({
+        variables: {
+          searchBoardInput: { page: 1, district: selectedDistrict },
+        },
       });
       setSelectedGenre(null);
     }
@@ -63,11 +67,15 @@ const MainList = () => {
     setSelectedDistrict(district);
 
     if (district === "undefined undefined") {
-      await refetch({ searchBoardInput: { page: 1, category: selectedGenre } });
+      await fetchBoardsBySearch({
+        variables: { searchBoardInput: { page: 1, category: selectedGenre } },
+      });
       setSelectedDistrict(null);
     } else {
-      await refetch({
-        searchBoardInput: { district, category: selectedGenre },
+      await fetchBoardsBySearch({
+        variables: {
+          searchBoardInput: { district, category: selectedGenre },
+        },
       });
     }
   };
@@ -120,6 +128,7 @@ const MainList = () => {
 
   const loadMore = async () => {
     if (boardsData === undefined) return;
+
     try {
       await fetchMore({
         variables: {

--- a/src/components/units/main/list/List.queries.ts
+++ b/src/components/units/main/list/List.queries.ts
@@ -10,7 +10,9 @@ export const FETCH_BOARDS = gql`
       end_time
       isShowTime
       createAt
-      updatedAt
+      artist {
+        active_name
+      }
       category {
         id
         name

--- a/src/components/units/main/list/ListItem.tsx
+++ b/src/components/units/main/list/ListItem.tsx
@@ -35,7 +35,7 @@ const ListItem = ({ board, onClickListItem }: IListItemProps) => {
                 color: "#9900ff",
               }}
             >
-              {board?.artist.active_name}
+              {board?.artist?.active_name}
             </span>
           </div>
           <ItemInfo>


### PR DESCRIPTION
### 이슈
> 리스트 페이지가 렌더링 될 때 마다 fetchBoardsBySearch가 호출됨 (이 API는 유저가 필터링을 작동시킬 때만 호출되어야 함)

### 해결
> fetchBoardsBySearch는 `useLazyQuery`를 사용해, 수동적인 호출로 변경.

closed #16 