### PR TITLE
:zap: (list): FEATURE: 리스트 페이지 동일한 API의 반복적인 호출 개선

### DIFF
--- a/src/commons/store/index.tsx
+++ b/src/commons/store/index.tsx
@@ -24,7 +24,10 @@ export const sidebarState = atom({
   default: false,
 });
 
-// export const districtDataState = atom({
-//   key: `districtListState${uniqueId()}`,
-//   default: {},
-// });
+export const userState = atom({
+  key: `userState${uniqueId()}`,
+  default: {
+    isLoggedIn: false,
+    isArtist: false,
+  },
+});

--- a/src/components/units/login/Login.Quries.ts
+++ b/src/components/units/login/Login.Quries.ts
@@ -5,3 +5,11 @@ export const LOGIN = gql`
     login(email: $email, password: $password)
   }
 `;
+
+export const FETCH_ARTIST = gql`
+  query {
+    fetchArtist {
+      id
+    }
+  }
+`;

--- a/src/components/units/main/list/List.container.tsx
+++ b/src/components/units/main/list/List.container.tsx
@@ -9,12 +9,15 @@ import {
 import { FETCH_BOARDS_BY_SEARCH, FETCH_CATEGORIES } from "./List.queries";
 import DistrcitData from "./DistrictData";
 import { useState } from "react";
-import { FETCH_ARTIST } from "../../detail/ArtDetail.queries";
-import { FETCH_USER } from "../../myPage/detail/MyPageDetail.queries";
+import { useRecoilValue } from "recoil";
+import { userState } from "../../../../commons/store";
 
 const MainList = () => {
   const router = useRouter();
   const locationOptions = [...DistrcitData];
+  const currUserState = useRecoilValue(userState);
+
+  console.log(currUserState);
 
   const {
     data: boardsData,
@@ -25,9 +28,6 @@ const MainList = () => {
     IQueryFetchBoardsBySearchArgs
   >(FETCH_BOARDS_BY_SEARCH);
 
-  const { data: isArtist } =
-    useQuery<Pick<IQuery, "fetchArtist">>(FETCH_ARTIST);
-  const { data: isUser } = useQuery<Pick<IQuery, "fetchUser">>(FETCH_USER);
   const { data: categoryData } =
     useQuery<Pick<IQuery, "fetchCategories">>(FETCH_CATEGORIES);
 
@@ -75,7 +75,7 @@ const MainList = () => {
   };
 
   const onClickToMap = async () => {
-    if (isUser) {
+    if (currUserState.isLoggedIn) {
       await router.push("/map");
     } else {
       Modal.warning({
@@ -88,9 +88,9 @@ const MainList = () => {
   };
 
   const onClickMoveToArtRegister = async () => {
-    if (isArtist) {
+    if (currUserState.isArtist) {
       await router.push("/artregister");
-    } else if (isUser) {
+    } else if (currUserState.isLoggedIn) {
       Modal.confirm({
         content: (
           <div style={{ width: "100%", textAlign: "center" }}>
@@ -111,8 +111,8 @@ const MainList = () => {
       Modal.warning({
         bodyStyle: { fontSize: "1.5rem" },
         content: "로그인 후에 이용하실 수 있습니다.",
+        onOk: async () => await router.push("/login"),
       });
-      await router.push("/login");
     }
   };
 


### PR DESCRIPTION
### 이슈 
리스트 페이지 진입 시, fetchUser와 fetchArtist의 반복적인 호출 
### 해결 
리스트 페이지에서 fetchUser, fetchArtist 삭제. 로그인 상태와 아티스트인지 여부를 전역 상태로 관리하도록 변경

closed #19